### PR TITLE
Pulse counter rewrite

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,27 +12,30 @@ void setup() {
   Serial.begin(115200);
   
 
-  //configure whether pins will be sending or receiving data
-  setup_motor();
-  Serial.println("setup motor finished");
-  setup_hall();
-  Serial.println("setup hall finished");
-  setup_potentiometer();
-  Serial.println("setup potentiometer finished");
+  // //configure whether pins will be sending or receiving data
+  // setup_motor();
+  // Serial.println("setup motor finished");
+  // setup_hall();
+  // Serial.println("setup hall finished");
+  // setup_potentiometer();
+  // Serial.println("setup potentiometer finished");
 
-  setup_pid_task();
-  Serial.println("setup pid finished");  
+  // setup_pid_task();
+  // Serial.println("setup pid finished");  
   
   init_pulse_counter();
   Serial.println("setup hall pulse counter finished");
 
-  Serial.println("Setup Complete");
+  
+
+  // Serial.println("Setup Complete");
 
 }
 
 void loop() {
 
-  delay(100);
+  Serial.printf("counts: %d\n", get_primary_counter());
+  delay(250);
 
 }
 

--- a/src/pid.cpp
+++ b/src/pid.cpp
@@ -132,7 +132,7 @@ void pid_loop_task(void *pvParameters)
         Serial.printf(">rpm: %f\n", rpm);
         // Serial.printf(">targetRPM: %d\n", targetRPM);
 
-        // Serial.printf(">count: %d\n", get_pulse_counter());
+        // Serial.printf(">count: %d\n", get_primary_counter());
         // Serial.printf(">deltaCount: %f\n", deltaCount);
         // Serial.printf(">deltaT: %f\n", deltaT);
         static int counter = 0;

--- a/src/pins.h
+++ b/src/pins.h
@@ -1,7 +1,7 @@
 #define POT_PIN 32 // measures at potentiometer slider
 #define PWM_PIN 13 // SV on driver, sends pulses to the motor 
 #define DIRECTION_PIN 26 // F/R on driver, controls the motor's direction
-#define HALL_OUTPUT_PIN 33 // reads each time the hall sensor passes a magnet
+#define HALL_OUTPUT_PIN 14 // reads each time the hall sensor passes a magnet
 #define ENCODER_A 27
 #define ENCODER_B 14
 

--- a/src/pulseCounter.cpp
+++ b/src/pulseCounter.cpp
@@ -5,10 +5,10 @@
 
 pcnt_config_t pcnt_config;
 
-//pins and unit for primary hall sensor
-pcnt_unit_t primary_counter_id = PCNT_UNIT_1;
-int PCNT_INPUT_SIG_IO = PCNT_PIN_NOT_USED;
-int PCNT_INPUT_CTRL_IO = HALL_OUTPUT_PIN;
+// pins and unit for primary hall sensor
+pcnt_unit_t primary_counter_id = PCNT_UNIT_0;
+int PCNT_INPUT_SIG_IO = HALL_OUTPUT_PIN;
+int PCNT_INPUT_CTRL_IO = PCNT_PIN_NOT_USED;
 
 
 // initialize the primary pulse counter
@@ -21,6 +21,17 @@ void init_pulse_counter()
     pcnt_config.pulse_gpio_num = PCNT_INPUT_SIG_IO;
     pcnt_config.ctrl_gpio_num = PCNT_INPUT_CTRL_IO;
     pcnt_unit_config(&pcnt_config);
+
+    // set counting mode for primary counter, count both rising and falling edges
+    pcnt_set_mode(primary_counter_id, PCNT_CHANNEL_0, PCNT_COUNT_INC, PCNT_COUNT_INC, PCNT_MODE_KEEP, PCNT_MODE_KEEP);
+
+    // set filter value to ignore glitches, this is in units of APB clock cycles, so for 80MHz clock, 1000 = 12.5us
+    pcnt_set_filter_value(primary_counter_id, 1000); 
+    pcnt_filter_enable(primary_counter_id);
+
+    // clear and start the counter
+    pcnt_counter_clear(primary_counter_id);
+    pcnt_counter_resume(primary_counter_id);
 }
 
 // get the current count of the primary pulse counter

--- a/src/pulseCounter.h
+++ b/src/pulseCounter.h
@@ -1,5 +1,3 @@
-
-
 void init_pulse_counter();
-int get_pulse_counter();
+int get_primary_counter();
 float get_engine_rpm();


### PR DESCRIPTION
rewrote the pulse counter code to use the Espressif Pulse Counter API instead of a 3rd party library, since the 3rd party library did not allow you to specify which PCNT unit to use, which caused issues when the Encoder Library and Pulse counter libraries tried to use the same unit. 